### PR TITLE
OpenGL failure leads in a core dump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,9 @@ RUN chown ${HOST_USERNAME}:${HOST_GID} /home/${HOST_USERNAME}/.config
 # Set the path for QT to find the keyboard context
 ENV QT_XKB_CONFIG_ROOT /usr/share/X11/xkb
 
+# Prevent OpenGL error
+ENV QT_QUICK_BACKEND=software
+
 # Enter!
 ENTRYPOINT pcoip-client
 


### PR DESCRIPTION
Addition to Dockerfile to avoid a core dump with  Failed to create OpenGL context for format QSurfaceFormat
The idea is based on https://stackoverflow.com/questions/69049171/how-to-fix-libgl-error-in-qt5-qml-gui-launched-from-docker-on-linux